### PR TITLE
Even faster chessjs (#3)

### DIFF
--- a/__tests__/chess.test.js
+++ b/__tests__/chess.test.js
@@ -275,7 +275,8 @@ describe("Get/Put/Remove", function() {
               b6: {type: chess.QUEEN, color: chess.BLACK},
               a4: {type: chess.KING, color: chess.WHITE},
               h4: {type: chess.KING, color: chess.BLACK}},
-     should_pass: true},
+     
+      should_pass: true},
 
     {pieces: {a7: {type: 'z', color: chess.WHTIE}}, // bad piece
      should_pass: false},


### PR DESCRIPTION
Make chess.js faster by a significant amount.  Generate moves for a move based on the piece moving.  Store references to generate_moves results instead of recalling it multiple times.  Tests take ~3seconds.